### PR TITLE
chore(release): harden publish script and add manual release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,61 @@
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      expect_tag:
+        description: "Tag to require before publish (example: v0.6.0)"
+        required: true
+        type: string
+      dry_run:
+        description: "Run cargo publish --dry-run only"
+        required: true
+        default: true
+        type: boolean
+
+jobs:
+  verify:
+    name: Verify release candidate
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy, rustfmt
+
+      - name: Check formatting
+        run: cargo fmt --all -- --check
+
+      - name: Clippy (deny warnings)
+        run: cargo clippy --all-features -- -D warnings
+
+      - name: Run tests
+        run: cargo test --all
+
+  publish:
+    name: Publish crates
+    runs-on: ubuntu-latest
+    needs: verify
+    env:
+      EXPECT_TAG: ${{ inputs.expect_tag }}
+      DRY_RUN: ${{ inputs.dry_run && '1' || '0' }}
+
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Publish
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: ./hack/publish.sh

--- a/hack/publish.sh
+++ b/hack/publish.sh
@@ -19,7 +19,13 @@ set -euo pipefail
 #   ./publish.sh           # live run
 #   DRY_RUN=1 ./publish.sh # "cargo publish --dry-run" for all crates
 #
+# Optional env:
+#   EXPECT_TAG=v0.6.0      # require this git tag to exist
+#
 ###############################################################################
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
 
 CRATES=(
   "crates/artificial-core"
@@ -28,6 +34,25 @@ CRATES=(
   "crates/artificial-openai"
   "crates/artificial"
 )
+
+CURRENT_BRANCH="$(git rev-parse --abbrev-ref HEAD)"
+if [[ "$CURRENT_BRANCH" != "master" && "$CURRENT_BRANCH" != "main" ]]; then
+  echo "❌ Refusing to publish from branch '$CURRENT_BRANCH'. Use 'master' or 'main'."
+  exit 1
+fi
+
+if [[ -n "${EXPECT_TAG:-}" ]]; then
+  if ! git rev-parse --verify --quiet "refs/tags/$EXPECT_TAG" >/dev/null; then
+    echo "❌ Expected tag '$EXPECT_TAG' does not exist."
+    exit 1
+  fi
+fi
+
+# Ensure repository is clean before publishing any crate.
+if [[ -n "$(git status --porcelain)" ]]; then
+  echo "❌ Working tree is not clean – aborting."
+  exit 1
+fi
 
 # Allow a dry-run mode: DRY_RUN=1 ./publish.sh
 PUBLISH_CMD="cargo publish --locked"
@@ -42,12 +67,8 @@ for crate in "${CRATES[@]}"; do
   echo "─────────────────────────────────────────────────────────────"
 
   pushd "$crate" > /dev/null
-  # Ensure version tag exists and working tree is clean.
-  echo "→ Checking git status…"
-  if [[ -n $(git status --porcelain) ]]; then
-    echo "⚠️  Working directory not clean in $crate – aborting."
-    exit 1
-  fi
+  echo "→ Packaging check…"
+  cargo package --locked
 
   # Perform the (dry-)publish
   $PUBLISH_CMD


### PR DESCRIPTION
## Summary
- add a manual release workflow at `.github/workflows/release.yml`
  - `workflow_dispatch` inputs: `expect_tag`, `dry_run`
  - verify job runs fmt/clippy/tests before publish
  - publish job runs `./hack/publish.sh` with `EXPECT_TAG`/`DRY_RUN`
- harden `hack/publish.sh`
  - require release branch to be `master` or `main`
  - require clean working tree before publish
  - optionally require tag via `EXPECT_TAG`
  - run `cargo package --locked` per crate before publish

## Why
This reduces accidental publishes and makes releases repeatable through CI.

## Validation
- `bash -n hack/publish.sh`
- `cargo check --workspace`