### PR TITLE
Add provider-agnostic transcription API, OpenAI implementation, example and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,11 @@ need a lean starting point for your own experiments—this repo is for you.
 1. [Crate layout](#crate-layout)
 2. [Installation](#installation)
 3. [Quick start](#quick-start)
-4. [Library tour](#library-tour)
-5. [Design goals](#design-goals)
-6. [FAQ](#faq)
-7. [License](#license)
+4. [Audio transcription](#audio-transcription)
+5. [Library tour](#library-tour)
+6. [Design goals](#design-goals)
+7. [FAQ](#faq)
+8. [License](#license)
 
 ---
 
@@ -132,6 +133,27 @@ cargo run -p artificial --example openai_hello_world
 
 The program sends a request with an **inline JSON-Schema** and prints the
 deserialised reply.
+
+---
+
+## Audio transcription
+
+`artificial-core` now exposes a provider-agnostic transcription capability via:
+
+- `TranscriptionRequest`
+- `TranscriptionResult`
+- `TranscriptionProvider`
+
+The OpenAI adapter implements this against `/audio/transcriptions`.
+
+Working example:
+
+```bash
+OPENAI_API_KEY=... cargo run -p artificial --example openai_audio_transcription -- ./sample.wav
+```
+
+Example source:
+[`crates/artificial/examples/openai_audio_transcription.rs`](crates/artificial/examples/openai_audio_transcription.rs)
 
 ---
 

--- a/crates/artificial-core/src/client.rs
+++ b/crates/artificial-core/src/client.rs
@@ -36,7 +36,7 @@ use crate::{
     generic::{GenericChatCompletionResponse, StreamingEventsProvider},
     provider::{
         ChatCompleteParameters, ChatCompletionProvider, PromptExecutionProvider,
-        StreamingChatProvider,
+        StreamingChatProvider, TranscriptionProvider, TranscriptionRequest, TranscriptionResult,
     },
     template::{IntoPrompt, PromptTemplate},
 };
@@ -135,5 +135,14 @@ impl<B: StreamingEventsProvider> StreamingEventsProvider for ArtificialClient<B>
         M: Into<Self::Message> + Clone + Send + Sync + 's,
     {
         self.backend.chat_complete_events_stream(params)
+    }
+}
+
+impl<B: TranscriptionProvider> TranscriptionProvider for ArtificialClient<B> {
+    fn transcribe<'s>(
+        &'s self,
+        request: TranscriptionRequest,
+    ) -> Pin<Box<dyn Future<Output = Result<TranscriptionResult>> + Send + 's>> {
+        self.backend.transcribe(request)
     }
 }

--- a/crates/artificial-core/src/provider/mod.rs
+++ b/crates/artificial-core/src/provider/mod.rs
@@ -3,3 +3,5 @@ pub use chat_complete::*;
 mod prompt_execute;
 pub use crate::generic::StreamingEventsProvider;
 pub use prompt_execute::*;
+mod transcription;
+pub use transcription::*;

--- a/crates/artificial-core/src/provider/transcription.rs
+++ b/crates/artificial-core/src/provider/transcription.rs
@@ -1,0 +1,71 @@
+use std::{future::Future, pin::Pin};
+
+use crate::error::Result;
+
+/// Provider-agnostic audio transcription request.
+#[derive(Debug, Clone)]
+pub struct TranscriptionRequest {
+    pub audio: Vec<u8>,
+    pub mime_type: String,
+    pub filename: Option<String>,
+    pub language: Option<String>,
+    pub prompt: Option<String>,
+    pub model: Option<String>,
+}
+
+impl TranscriptionRequest {
+    pub fn new(audio: Vec<u8>, mime_type: impl Into<String>) -> Self {
+        Self {
+            audio,
+            mime_type: mime_type.into(),
+            filename: None,
+            language: None,
+            prompt: None,
+            model: None,
+        }
+    }
+
+    pub fn with_filename(mut self, filename: impl Into<String>) -> Self {
+        self.filename = Some(filename.into());
+        self
+    }
+
+    pub fn with_language(mut self, language: impl Into<String>) -> Self {
+        self.language = Some(language.into());
+        self
+    }
+
+    pub fn with_prompt(mut self, prompt: impl Into<String>) -> Self {
+        self.prompt = Some(prompt.into());
+        self
+    }
+
+    pub fn with_model(mut self, model: impl Into<String>) -> Self {
+        self.model = Some(model.into());
+        self
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct TranscriptionSegment {
+    pub start_seconds: Option<f64>,
+    pub end_seconds: Option<f64>,
+    pub text: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct TranscriptionResult {
+    pub text: String,
+    pub language: Option<String>,
+    pub duration_seconds: Option<f64>,
+    pub segments: Option<Vec<TranscriptionSegment>>,
+    pub metadata: Option<serde_json::Value>,
+}
+
+/// Provider capability for converting audio to text.
+pub trait TranscriptionProvider: Send + Sync {
+    fn transcribe<'s>(
+        &'s self,
+        request: TranscriptionRequest,
+    ) -> Pin<Box<dyn Future<Output = Result<TranscriptionResult>> + Send + 's>>;
+}

--- a/crates/artificial-openai/src/api_v1/audio_transcription.rs
+++ b/crates/artificial-openai/src/api_v1/audio_transcription.rs
@@ -1,0 +1,53 @@
+use std::collections::HashMap;
+
+use artificial_core::provider::{TranscriptionResult, TranscriptionSegment};
+use serde::Deserialize;
+
+#[derive(Debug, Deserialize)]
+pub struct AudioTranscriptionResponse {
+    pub text: String,
+    #[serde(default)]
+    pub language: Option<String>,
+    #[serde(default)]
+    pub duration: Option<f64>,
+    #[serde(default)]
+    pub segments: Option<Vec<AudioTranscriptionSegment>>,
+    #[serde(flatten)]
+    pub metadata: HashMap<String, serde_json::Value>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct AudioTranscriptionSegment {
+    #[serde(default)]
+    pub start: Option<f64>,
+    #[serde(default)]
+    pub end: Option<f64>,
+    pub text: String,
+}
+
+impl From<AudioTranscriptionResponse> for TranscriptionResult {
+    fn from(value: AudioTranscriptionResponse) -> Self {
+        Self {
+            text: value.text,
+            language: value.language,
+            duration_seconds: value.duration,
+            segments: value.segments.map(|segments| {
+                segments
+                    .into_iter()
+                    .map(|segment| TranscriptionSegment {
+                        start_seconds: segment.start,
+                        end_seconds: segment.end,
+                        text: segment.text,
+                    })
+                    .collect()
+            }),
+            metadata: if value.metadata.is_empty() {
+                None
+            } else {
+                Some(serde_json::Value::Object(
+                    value.metadata.into_iter().collect(),
+                ))
+            },
+        }
+    }
+}

--- a/crates/artificial-openai/src/api_v1/mod.rs
+++ b/crates/artificial-openai/src/api_v1/mod.rs
@@ -1,7 +1,9 @@
+mod audio_transcription;
 mod chat_completion;
 mod chat_completion_stream;
 mod common;
 mod tools;
 
+pub use audio_transcription::*;
 pub use chat_completion::*;
 pub use chat_completion_stream::*;

--- a/crates/artificial-openai/src/client.rs
+++ b/crates/artificial-openai/src/client.rs
@@ -8,8 +8,13 @@ use reqwest::{
 };
 use std::time::Duration;
 
+use artificial_core::provider::{TranscriptionRequest, TranscriptionResult};
+
 use crate::{
-    api_v1::{ChatCompletionChunkResponse, ChatCompletionRequest, ChatCompletionResponse},
+    api_v1::{
+        AudioTranscriptionResponse, ChatCompletionChunkResponse, ChatCompletionRequest,
+        ChatCompletionResponse,
+    },
     error::{OpenAiError, OpenAiRateLimitHeaders},
 };
 
@@ -400,6 +405,76 @@ impl OpenAiClient {
             }
         }
     }
+
+    /// Perform an audio transcription via OpenAI `/audio/transcriptions`.
+    pub async fn audio_transcription(
+        &self,
+        request: TranscriptionRequest,
+    ) -> Result<TranscriptionResult, OpenAiError> {
+        if request.audio.is_empty() {
+            return Err(OpenAiError::Format(
+                "audio payload must not be empty".into(),
+            ));
+        }
+        if request.mime_type.trim().is_empty() {
+            return Err(OpenAiError::Format("mime_type must not be empty".into()));
+        }
+
+        use reqwest::multipart::{Form, Part};
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            AUTHORIZATION,
+            HeaderValue::from_str(&format!("Bearer {}", self.api_key)).unwrap(),
+        );
+
+        let filename = request.filename.unwrap_or_else(|| "audio.wav".to_string());
+        let file_part = Part::bytes(request.audio)
+            .file_name(filename)
+            .mime_str(&request.mime_type)
+            .map_err(|e| OpenAiError::Format(format!("invalid mime type: {e}")))?;
+
+        let mut form = Form::new().part("file", file_part).text(
+            "model",
+            request
+                .model
+                .unwrap_or_else(|| "gpt-4o-mini-transcribe".to_string()),
+        );
+
+        if let Some(language) = request.language {
+            form = form.text("language", language);
+        }
+        if let Some(prompt) = request.prompt {
+            form = form.text("prompt", prompt);
+        }
+
+        let url = format!("{}/audio/transcriptions", self.base);
+        let mut req = self.http.post(url).headers(headers).multipart(form);
+        if let Some(timeout) = self.timeouts.request_timeout {
+            req = req.timeout(timeout);
+        }
+        let resp = req.send().await?;
+
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let headers_map = resp.headers().clone();
+            let body = resp.text().await.unwrap_or_default();
+            if status == reqwest::StatusCode::TOO_MANY_REQUESTS {
+                let (retry_after, reset_at, headers) = extract_rate_limit_info(&headers_map);
+                return Err(OpenAiError::RateLimited {
+                    status,
+                    body,
+                    retry_after,
+                    reset_at,
+                    headers,
+                });
+            }
+            return Err(OpenAiError::Api { status, body });
+        }
+
+        let bytes = resp.bytes().await?;
+        let parsed: AudioTranscriptionResponse = serde_json::from_slice(&bytes)?;
+        Ok(parsed.into())
+    }
 }
 
 #[cfg(test)]
@@ -513,5 +588,52 @@ mod tests {
             .expect("stream should produce first chunk")
             .expect("first chunk should parse");
         assert_eq!(first.choices.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn audio_transcription_parses_text_response() {
+        let base_url = run_single_response_server(
+            Duration::from_millis(0),
+            r#"{"text":"hello world","language":"en","duration":1.25}"#.to_string(),
+            "application/json",
+        );
+
+        let client = OpenAiClient::with_http_and_timeouts(
+            "test-key",
+            reqwest::Client::new(),
+            Some(base_url),
+            HttpTimeoutConfig::default(),
+        )
+        .with_retry_policy(RetryPolicy {
+            max_retries: 0,
+            ..RetryPolicy::default()
+        });
+
+        let result = client
+            .audio_transcription(
+                TranscriptionRequest::new(vec![1, 2, 3], "audio/wav")
+                    .with_filename("clip.wav")
+                    .with_model("gpt-4o-mini-transcribe"),
+            )
+            .await
+            .expect("transcription should succeed");
+
+        assert_eq!(result.text, "hello world");
+        assert_eq!(result.language.as_deref(), Some("en"));
+        assert_eq!(result.duration_seconds, Some(1.25));
+    }
+
+    #[tokio::test]
+    async fn audio_transcription_rejects_empty_audio() {
+        let client = OpenAiClient::new("test-key");
+        let err = client
+            .audio_transcription(TranscriptionRequest::new(Vec::new(), "audio/wav"))
+            .await
+            .expect_err("empty audio should fail validation");
+
+        match err {
+            OpenAiError::Format(msg) => assert!(msg.contains("audio payload")),
+            other => panic!("unexpected error: {other:?}"),
+        }
     }
 }

--- a/crates/artificial-openai/src/lib.rs
+++ b/crates/artificial-openai/src/lib.rs
@@ -3,6 +3,7 @@ mod model_map;
 mod provider_impl_chat;
 mod provider_impl_chat_stream;
 mod provider_impl_prompt;
+mod provider_impl_transcription;
 
 pub use adapter::{OpenAiAdapter, OpenAiAdapterBuilder};
 mod api_v1;

--- a/crates/artificial-openai/src/provider_impl_transcription.rs
+++ b/crates/artificial-openai/src/provider_impl_transcription.rs
@@ -1,0 +1,18 @@
+use std::{future::Future, pin::Pin, sync::Arc};
+
+use artificial_core::{
+    error::Result,
+    provider::{TranscriptionProvider, TranscriptionRequest, TranscriptionResult},
+};
+
+use crate::OpenAiAdapter;
+
+impl TranscriptionProvider for OpenAiAdapter {
+    fn transcribe<'s>(
+        &'s self,
+        request: TranscriptionRequest,
+    ) -> Pin<Box<dyn Future<Output = Result<TranscriptionResult>> + Send + 's>> {
+        let client = Arc::clone(&self.client);
+        Box::pin(async move { Ok(client.audio_transcription(request).await?) })
+    }
+}

--- a/crates/artificial/examples/openai_audio_transcription.rs
+++ b/crates/artificial/examples/openai_audio_transcription.rs
@@ -1,0 +1,57 @@
+use std::path::PathBuf;
+
+use artificial::{
+    ArtificialClient,
+    openai::OpenAiAdapterBuilder,
+    provider::{TranscriptionProvider, TranscriptionRequest},
+};
+
+/// Basic audio transcription example.
+///
+/// Usage:
+///   OPENAI_API_KEY=... cargo run -p artificial --example openai_audio_transcription -- path/to/audio.wav
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let audio_path = std::env::args()
+        .nth(1)
+        .map(PathBuf::from)
+        .ok_or_else(|| anyhow::anyhow!("missing audio path arg"))?;
+
+    let audio = std::fs::read(&audio_path)?;
+    let mime_type = guess_mime_type(&audio_path);
+    let filename = audio_path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("audio.wav")
+        .to_string();
+
+    let backend = OpenAiAdapterBuilder::new_from_env().build()?;
+    let client = ArtificialClient::new(backend);
+
+    let request = TranscriptionRequest::new(audio, mime_type)
+        .with_filename(filename)
+        .with_model("gpt-4o-mini-transcribe");
+
+    let result = client.transcribe(request).await?;
+
+    println!("Transcription:\n{}", result.text);
+    if let Some(language) = result.language {
+        println!("Language: {language}");
+    }
+    if let Some(duration) = result.duration_seconds {
+        println!("Duration: {duration:.2}s");
+    }
+
+    Ok(())
+}
+
+fn guess_mime_type(path: &PathBuf) -> &'static str {
+    match path.extension().and_then(|ext| ext.to_str()) {
+        Some("mp3") => "audio/mpeg",
+        Some("m4a") => "audio/mp4",
+        Some("ogg") => "audio/ogg",
+        Some("webm") => "audio/webm",
+        Some("wav") => "audio/wav",
+        _ => "application/octet-stream",
+    }
+}


### PR DESCRIPTION
## Summary
- add provider-agnostic transcription capability in `artificial-core`
  - `TranscriptionRequest`
  - `TranscriptionResult`
  - `TranscriptionSegment`
  - `TranscriptionProvider` trait
- wire `ArtificialClient` to delegate `transcribe(...)`
- implement OpenAI `/audio/transcriptions` in `artificial-openai`
- add OpenAI adapter implementation of `TranscriptionProvider`
- add a working example:
  - `crates/artificial/examples/openai_audio_transcription.rs`
- add README docs section for audio transcription usage
- add tests for transcription success parsing and request validation errors

## Validation
- `cargo fmt --all`
- `cargo test --workspace`

Closes #20