### PR TITLE
chore: ignore wav files in git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ Cargo.lock
 
 # Editors
 /.idea
+*.wav


### PR DESCRIPTION
Add `*.wav` to `.gitignore` so local audio recordings used for transcription testing do not get committed.