### PR TITLE
Add OpenAI provider options builder API (with compatibility alias)

### DIFF
--- a/crates/artificial-openai/src/adapter.rs
+++ b/crates/artificial-openai/src/adapter.rs
@@ -23,14 +23,14 @@ pub struct OpenAiAdapter {
 
 impl OpenAiAdapter {}
 
-/// Builder for [`OpenAiAdapter`].
+/// Builder-style configuration for constructing [`OpenAiAdapter`].
 ///
 /// # Typical usage
 ///
 /// ```rust,no_run
-/// use artificial_openai::OpenAiAdapterBuilder;
+/// use artificial_openai::OpenAiAdapterOptions;
 ///
-/// let backend = OpenAiAdapterBuilder::new_from_env()
+/// let backend = OpenAiAdapterOptions::new_from_env()
 ///     .build()
 ///     .expect("OPENAI_API_KEY must be set");
 /// ```
@@ -38,13 +38,13 @@ impl OpenAiAdapter {}
 /// The builder pattern keeps future options (proxy URL, organisation ID, …)
 /// backwards compatible without breaking existing `build()` calls.
 #[derive(Default)]
-pub struct OpenAiAdapterBuilder {
+pub struct OpenAiAdapterOptions {
     pub(crate) api_key: Option<String>,
     pub(crate) retry: Option<RetryPolicy>,
     pub(crate) timeouts: Option<HttpTimeoutConfig>,
 }
 
-impl OpenAiAdapterBuilder {
+impl OpenAiAdapterOptions {
     /// Create an *empty* builder. Remember to supply an API key manually.
     pub fn new() -> Self {
         Self::default()
@@ -62,6 +62,12 @@ impl OpenAiAdapterBuilder {
             retry: None,
             timeouts: None,
         }
+    }
+
+    /// Set API key explicitly.
+    pub fn with_api_key(mut self, api_key: impl Into<String>) -> Self {
+        self.api_key = Some(api_key.into());
+        self
     }
 
     /// Set a retry policy for OpenAI HTTP calls.
@@ -100,3 +106,6 @@ impl OpenAiAdapterBuilder {
         })
     }
 }
+
+/// Backwards-compatible alias kept for existing code.
+pub type OpenAiAdapterBuilder = OpenAiAdapterOptions;

--- a/crates/artificial-openai/src/lib.rs
+++ b/crates/artificial-openai/src/lib.rs
@@ -5,7 +5,7 @@ mod provider_impl_chat_stream;
 mod provider_impl_prompt;
 mod provider_impl_transcription;
 
-pub use adapter::{OpenAiAdapter, OpenAiAdapterBuilder};
+pub use adapter::{OpenAiAdapter, OpenAiAdapterBuilder, OpenAiAdapterOptions};
 mod api_v1;
 mod client;
 pub use client::{HttpTimeoutConfig, RetryPolicy};


### PR DESCRIPTION
## Summary
- add `OpenAiAdapterOptions` as the primary builder-style provider options struct
- keep `OpenAiAdapterBuilder` as a type alias for backward compatibility
- add explicit `with_api_key(...)` to support fully fluent configuration
- export `OpenAiAdapterOptions` from crate root

## Why
Issue #25 requests a consistent builder pattern on provider option structs instead of relying on only `new/new_from_env` patterns.

## Validation
- `cargo fmt --all`
- `cargo test --workspace`

Closes #25